### PR TITLE
add a default version in case we cannot get it from build args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ TAG_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
 TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
 COMMIT := $(shell git rev-parse --short HEAD)
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
-VERSION := $(TAG:v%=%)
 APPPKG := $(PROJECT_ROOT)/app
-LINKER_FLAGS := -X $(APPPKG).BuildDate=$(DATE) -X $(APPPKG).Commit=$(COMMIT) -X $(APPPKG).Version=$(VERSION)
+LINKER_FLAGS := -X $(APPPKG).BuildDate=$(DATE) -X $(APPPKG).Commit=$(COMMIT) -X $(APPPKG).Version=$(TAG)
 
 
 ALL_SRC := $(shell find . -name "*.go")

--- a/app/connection.go
+++ b/app/connection.go
@@ -44,7 +44,7 @@ func GetServerConnection(c *cli.Context) (context.Context, *grpc.ClientConn, err
 	}
 	ctx := context.Background()
 
-	ctx = metadata.AppendToOutgoingContext(ctx, "tcld-version", Version)
+	ctx = metadata.AppendToOutgoingContext(ctx, "tcld-version", getVersion())
 	ctx = metadata.AppendToOutgoingContext(ctx, "tcld-commit", Commit)
 
 	if len(tokens.AccessToken) > 0 {

--- a/app/version.go
+++ b/app/version.go
@@ -2,6 +2,10 @@ package app
 
 import "github.com/urfave/cli/v2"
 
+const (
+	DefaultVersion = "0.1.1"
+)
+
 var (
 	BuildDate string
 	Commit    string
@@ -25,4 +29,12 @@ func NewVersionCommand() (CommandOut, error) {
 			})
 		},
 	}}, nil
+}
+
+func getVersion() string {
+	version := Version
+	if len(version) == 0 {
+		version = DefaultVersion
+	}
+	return version
 }

--- a/app/version.go
+++ b/app/version.go
@@ -3,7 +3,7 @@ package app
 import "github.com/urfave/cli/v2"
 
 const (
-	DefaultVersion = "0.1.1"
+	DefaultVersion = "v0.1.1"
 )
 
 var (

--- a/app/version.go
+++ b/app/version.go
@@ -25,7 +25,7 @@ func NewVersionCommand() (CommandOut, error) {
 			}{
 				BuildDate: BuildDate,
 				Commit:    Commit,
-				Version:   Version,
+				Version:   getVersion(),
 			})
 		},
 	}}, nil


### PR DESCRIPTION
## What was changed
add a default version in case we cannot get it from build args

## Why?
so that we can still got a version even when tcld is not installed using build args
