### PR TITLE
Add tcld.rb home brew formula

### DIFF
--- a/brew/tcld.rb
+++ b/brew/tcld.rb
@@ -1,0 +1,22 @@
+class Tcld < Formula
+  desc "Temporal Cloud CLI (tcld)"
+  homepage "https://temporal.io/"
+  url "https://github.com/temporalio/tcld/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "91b56d5f5e4c0a6a36272db31daa1da635156202138bee3ab810be93b82f7301"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"tcld", "./cmd/tcld/main.go", "./cmd/tcld/fx.go"
+  end
+
+  test do
+    # Given tcld is pointless without a server, not much intersting to test here.
+    run_output = shell_output("#{bin}/tcld version 2>&1")
+    assert_match "Version", run_output
+
+    run_output = shell_output("#{bin}/tcld -s localhost:1234 n l 2>&1")
+    assert_match "rpc error", run_output
+  end
+end


### PR DESCRIPTION
We need to self host the formula until it becomes more popular and is submitted to home brew core by a third party.

Reference to rejected pull request to homebrew core: https://github.com/Homebrew/homebrew-core/pull/100887

The homebrew error we're failing on:
```
brew audit --new tcld
tcld:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```