### PR TITLE
update installation to include homebrew and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A cli tool for managing Temporal Cloud namespaces.
 > This cli tool is currently in `beta` and access to Temporal Cloud via the cli is restricted. Please reach out to temporal-cloud support for more information.
 
 # Installation
+## Install via Homebrew
+```
+brew install temporalio/brew/tcld
+```
 ## Build from source
 1. Verify that you have Go 1.18+ installed. If `go` is not installed, follow instructions on [the Go website](https://golang.org/doc/install).
 ```

--- a/app/version.go
+++ b/app/version.go
@@ -3,7 +3,7 @@ package app
 import "github.com/urfave/cli/v2"
 
 const (
-	DefaultVersion = "v0.1.1"
+	DefaultVersion = "v0.1.2"
 )
 
 var (


### PR DESCRIPTION
## What was changed
update installation to include homebrew and bump version

## Why?
we can install tcld with homebrew now

1. How was this tested:
unit tests

3. Any docs updates needed?
yes