### PR TITLE
support optional grpc.DialOption to GetServerConnection

### DIFF
--- a/app/connection.go
+++ b/app/connection.go
@@ -12,10 +12,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func GetServerConnection(c *cli.Context) (context.Context, *grpc.ClientConn, error) {
+func GetServerConnection(c *cli.Context, opts ...grpc.DialOption) (context.Context, *grpc.ClientConn, error) {
 
 	serverAddr := c.String(ServerFlagName)
-	var option grpc.DialOption
+	var credentialOption grpc.DialOption
 	parts := strings.Split(serverAddr, ":")
 
 	if len(parts) != 2 {
@@ -25,16 +25,16 @@ func GetServerConnection(c *cli.Context) (context.Context, *grpc.ClientConn, err
 	hostname := parts[0]
 	switch hostname {
 	case "localhost":
-		option = grpc.WithInsecure()
+		credentialOption = grpc.WithInsecure()
 	default:
-		option = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		credentialOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			MinVersion: tls.VersionTLS12,
 			ServerName: hostname,
 		}))
 	}
 	conn, err := grpc.Dial(
 		serverAddr,
-		option,
+		append(opts, credentialOption)...,
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
support optional grpc.DialOption to GetServerConnection

## Why?
<!-- Tell your future self why have you made these changes -->
to support plugin for specifying extra dial options to grpc connection

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
no

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no
