### PR TITLE
Make the config directory only accessible to the owning user

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -91,7 +91,7 @@ func loadLoginConfig(ctx *cli.Context) (OauthTokenResponse, error) {
 	tokens := OauthTokenResponse{}
 	configDir := ctx.Path(ConfigDirFlagName)
 	// Create config dir if it does not exist
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return tokens, err
 	}
 

--- a/services/loginservice.go
+++ b/services/loginservice.go
@@ -40,7 +40,8 @@ func (c *loginService) OpenBrowser(url string) error {
 }
 
 func (c *loginService) WriteToConfigFile(configPath string, data string) error {
-	return ioutil.WriteFile(configPath, []byte(data), 0644)
+	// Write file as 0600 since it contains private keys.
+	return ioutil.WriteFile(configPath, []byte(data), 0600)
 }
 
 func (c *loginService) DeleteConfigFile(configPath string) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This makes our config directory only accessible to the owning user.

## Why?
<!-- Tell your future self why have you made these changes -->
Ensure a user is unable to read or modify another user's config directory.

## Checklist
- [x] Tested a tcld command with `oauth` and a pre-created config directory from an older version.
- [x] Tested a tcld command with `oauth` and no pre-created config directory.
