### PR TITLE
Hide EnableHMAC CLI flag to discourage experimental use

### DIFF
--- a/app/flags.go
+++ b/app/flags.go
@@ -73,6 +73,9 @@ var (
 		Usage:    "Enable the use of HMAC request signatures, requires setting an API key as well (experimental)",
 		EnvVars:  []string{"TEMPORAL_CLOUD_ENABLE_HMAC"},
 		Category: AuthenticationFlagCategory,
+		// Hide the enable HMAC flag as this is an artifact of experimenting with authentication methods, and will
+		// likely be removed in the next few weeks.
+		Hidden: true,
 	}
 	InsecureConnectionFlag = &cli.BoolFlag{
 		Name:     InsecureConnectionFlagName,

--- a/services/loginservice.go
+++ b/services/loginservice.go
@@ -50,10 +50,3 @@ func (c *loginService) DeleteConfigFile(configPath string) error {
 	}
 	return nil
 }
-
-func (c *loginService) DeleteConfigFile(configPath string) error {
-	if _, err := os.Stat(configPath); err == nil {
-		return os.RemoveAll(configPath)
-	}
-	return nil
-}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This makes the `EnableHMAC` CLI flag hidden.

## Why?
<!-- Tell your future self why have you made these changes -->
Discourage use of the flag as it an artifact of experimentation and will likely be removed in the next few weeks.

## Checklist
N/A