### PR TITLE
Add flag to only show export related commands

### DIFF
--- a/app/common.go
+++ b/app/common.go
@@ -1,7 +1,7 @@
 package app
 
 func IsFeatureEnabled(feature string) bool {
-	jsonData, err := getFeatureFlagJSON()
+	jsonData, err := getFeatureFlags()
 
 	if err != nil {
 		return false

--- a/app/common.go
+++ b/app/common.go
@@ -1,0 +1,18 @@
+package app
+
+func IsFeatureEnabled(feature string) bool {
+	featureFlagConfigPath := getFeatureFlagConfigPath()
+	jsonData, err := getFeatureFlagConfig(featureFlagConfigPath)
+
+	if err != nil {
+		return false
+	}
+
+	for _, featureFlag := range jsonData {
+		if featureFlag.Name == feature {
+			return featureFlag.Value
+		}
+	}
+
+	return false
+}

--- a/app/common.go
+++ b/app/common.go
@@ -1,8 +1,7 @@
 package app
 
 func IsFeatureEnabled(feature string) bool {
-	featureFlagConfigPath := getFeatureFlagConfigPath()
-	jsonData, err := getFeatureFlagConfig(featureFlagConfigPath)
+	jsonData, err := getFeatureFlagJSON()
 
 	if err != nil {
 		return false

--- a/app/feature.go
+++ b/app/feature.go
@@ -20,6 +20,11 @@ type FeatureFlag struct {
 	Value bool   `json:"Value"`
 }
 
+func getFeatureFlagJSON() ([]FeatureFlag, error) {
+	featureFlagConfigPath := getFeatureFlagConfigPath()
+	return getFeatureFlagConfig(featureFlagConfigPath)
+}
+
 func getFeatureFlagConfigPath() string {
 	return filepath.Join(ConfigDirFlag.Value, featureflagFileName)
 }
@@ -107,8 +112,7 @@ func NewFeatureCommand() (CommandOut, error) {
 					Aliases: []string{"g"},
 					Usage:   "get all feature flags Value",
 					Action: func(c *cli.Context) error {
-						featureFlagConfigPath := getFeatureFlagConfigPath()
-						jsonData, err := getFeatureFlagConfig(featureFlagConfigPath)
+						jsonData, err := getFeatureFlagJSON()
 
 						if err != nil {
 							return err

--- a/app/feature.go
+++ b/app/feature.go
@@ -63,7 +63,6 @@ func NewFeatureCommand() (CommandOut, error) {
 				if c.Bool(EnableExportFeatureFlag.Name) {
 					jsonData[EnableExportFeatureFlag.Name] = true
 					fmt.Println("Export feature enabled")
-
 				}
 
 				jsonString, err := json.Marshal(jsonData)

--- a/app/feature.go
+++ b/app/feature.go
@@ -75,7 +75,7 @@ func NewFeatureCommand() (CommandOut, error) {
 				{
 					Name:    "get",
 					Aliases: []string{"g"},
-					Usage:   "get all feature flags",
+					Usage:   "get all feature flags value",
 					Action: func(c *cli.Context) error {
 						featureFlagConfigPath := GetFeatureFlagConfigPath()
 						jsonData, err := GetFeatureFlagConfig(featureFlagConfigPath)

--- a/app/feature.go
+++ b/app/feature.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	EnableExportFeatureFlag = &cli.BoolFlag{
+		Name:     "enable-export",
+		Value:    false,
+		Usage:    "enable export commands",
+		Required: false,
+	}
+)
+
+func GetFeatureFlagConfigPath() string {
+	return ConfigDirFlag.Value + "/feature.json"
+}
+
+func GetFeatureFlagConfig(featureFlagConfigDir string) (map[string]bool, error) {
+	// create config file if not exist
+	if _, err := ioutil.ReadFile(featureFlagConfigDir); err != nil {
+		if err := ioutil.WriteFile(featureFlagConfigDir, []byte("{}"), 0644); err != nil {
+			return nil, err
+		}
+	}
+
+	content, err := ioutil.ReadFile(featureFlagConfigDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var jsonData map[string]bool
+	err = json.Unmarshal(content, &jsonData)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonData, nil
+}
+
+func NewFeatureCommand() (CommandOut, error) {
+	return CommandOut{
+		Command: &cli.Command{
+			Name:    "feature",
+			Aliases: []string{"f"},
+			Usage:   "feature commands",
+			Flags: []cli.Flag{
+				EnableExportFeatureFlag,
+			},
+			Action: func(c *cli.Context) error {
+				featureFlagConfigDir := GetFeatureFlagConfigPath()
+				jsonData, err := GetFeatureFlagConfig(featureFlagConfigDir)
+
+				if err != nil {
+					return err
+				}
+
+				if c.Bool(EnableExportFeatureFlag.Name) {
+					jsonData[EnableExportFeatureFlag.Name] = true
+					fmt.Println("Export feature enabled")
+
+				}
+
+				jsonString, err := json.Marshal(jsonData)
+				if err != nil {
+					return err
+				}
+
+				if err := ioutil.WriteFile(featureFlagConfigDir, jsonString, 0644); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	}, nil
+}

--- a/app/feature_test.go
+++ b/app/feature_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestToggleFeatureAndRead(t *testing.T) {
 	testFileName := uuid.NewString() + ".json"
-	_, err := getFeatureFlagConfig(testFileName)
+	_, err := getFeatureFlagsFromConfigFile(testFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,13 +19,13 @@ func TestToggleFeatureAndRead(t *testing.T) {
 	// Toggle test feature on
 	test_feature_flag := "test-feature"
 
-	err = toggle_feature_save_to_path(test_feature_flag, testFileName)
+	err = toggleFeatureSaveToPath(test_feature_flag, testFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the file.
-	jsonData, err := getFeatureFlagConfig(testFileName)
+	jsonData, err := getFeatureFlagsFromConfigFile(testFileName)
 
 	if err != nil {
 		t.Fatal(err)
@@ -37,13 +37,13 @@ func TestToggleFeatureAndRead(t *testing.T) {
 	}
 
 	// Toggle test feature off
-	err = toggle_feature_save_to_path(test_feature_flag, testFileName)
+	err = toggleFeatureSaveToPath(test_feature_flag, testFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the file.
-	jsonData, err = getFeatureFlagConfig(testFileName)
+	jsonData, err = getFeatureFlagsFromConfigFile(testFileName)
 
 	if err != nil {
 		t.Fatal(err)

--- a/app/feature_test.go
+++ b/app/feature_test.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFeatureFlagConfig(t *testing.T) {
+	// Create a temporary file.
+	tmpfile, err := ioutil.TempFile("", "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	// Write a JSON object to the temporary file.
+	featureFlag := map[string]bool{"enable-export": true}
+	b, err := json.Marshal(featureFlag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmpfile.Write(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call the function under test.
+	result, err := GetFeatureFlagConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that the function correctly read the feature flag from the file.
+	assert.Equal(t, featureFlag, result)
+}

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -979,7 +979,7 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 	}
 
 	// Export Command
-	if jsonData[EnableExportFeatureFlag.Name] {
+	if jsonData[ExportFeatureFlag] {
 		subCommands = append(subCommands, &cli.Command{
 			Name:    "export",
 			Usage:   "Manage export sinks",
@@ -995,9 +995,6 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 			var err error
 			c, err = getNamespaceClientFn(ctx)
 			return err
-		},
-		Flags: []cli.Flag{
-			EnableExportFeatureFlag,
 		},
 		Subcommands: subCommands,
 	}

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/mail"
-	"os"
 	"strings"
 
 	"github.com/temporalio/tcld/protogen/api/auth/v1"
@@ -56,13 +55,6 @@ var (
 		"eu-west-2",
 		"us-east-1",
 		"us-west-2",
-	}
-	EnableExportFeatureFlag = &cli.BoolFlag{
-		Name:     "enable-export",
-		Value:    false,
-		Usage:    "enable export commands",
-		Required: false,
-		Hidden:   true,
 	}
 )
 
@@ -979,15 +971,20 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 		},
 	}
 
-	argsWithoutProg := os.Args[1:]
-	for _, arg := range argsWithoutProg {
-		if arg == "--"+EnableExportFeatureFlag.Name {
-			subCommands = append(subCommands, &cli.Command{
-				Name:    "export",
-				Usage:   "Manage export sinks",
-				Aliases: []string{"es"},
-			})
-		}
+	// ----------- Commands for private review feature, only available when feature flag turns on -----------
+	featureFlagConfigDir := GetFeatureFlagConfigPath()
+	jsonData, err := GetFeatureFlagConfig(featureFlagConfigDir)
+	if err != nil {
+		return CommandOut{}, err
+	}
+
+	// Export Command
+	if jsonData[EnableExportFeatureFlag.Name] {
+		subCommands = append(subCommands, &cli.Command{
+			Name:    "export",
+			Usage:   "Manage export sinks",
+			Aliases: []string{"es"},
+		})
 	}
 
 	command := &cli.Command{

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -972,14 +972,8 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 	}
 
 	// ----------- Commands for private review feature, only available when feature flag turns on -----------
-	featureFlagConfigDir := GetFeatureFlagConfigPath()
-	jsonData, err := GetFeatureFlagConfig(featureFlagConfigDir)
-	if err != nil {
-		return CommandOut{}, err
-	}
-
 	// Export Command
-	if jsonData[ExportFeatureFlag] {
+	if IsFeatureEnabled(ExportFeatureFlag) {
 		subCommands = append(subCommands, &cli.Command{
 			Name:    "export",
 			Usage:   "Manage export sinks",

--- a/cmd/tcld/fx.go
+++ b/cmd/tcld/fx.go
@@ -22,6 +22,7 @@ func fxOptions() fx.Option {
 			app.NewLoginCommand,
 			app.NewLogoutCommand,
 			app.NewCertificatesCommand,
+			app.NewFeatureCommand,
 			func() app.GetNamespaceClientFn {
 				return app.GetNamespaceClient
 			},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
In namespace.go, there is nothing change related to subCommands. subCommands is completely copy and paste. The change I made is from line 974-1005. So this is for only showing export commands when "export" feature flag enabled. 

1. tcld feature command

<img width="679" alt="image" src="https://github.com/temporalio/tcld/assets/124640969/5daf93cf-0418-4edd-9553-a04fe56a88a4">

2. show export command only when enable-export is true

<img width="1233" alt="image" src="https://github.com/temporalio/tcld/assets/124640969/1fe656cb-86e5-4c14-b315-3272c0c15140">


feature file will be json format, its content:

{"enable-export":true}


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
