### PR TITLE
Add response verification when requesting the OAuth device code

### DIFF
--- a/app/connection_test.go
+++ b/app/connection_test.go
@@ -57,7 +57,7 @@ func (s *ServerConnectionTestSuite) TestServerName() {
 			s.Require().NoError(err)
 			defer os.RemoveAll(testConfDir)
 
-			data, err := json.Marshal(OauthTokenResponse{
+			data, err := json.Marshal(OAuthTokenResponse{
 				AccessToken: testToken,
 			})
 			s.Require().NoError(err)

--- a/app/login.go
+++ b/app/login.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/temporalio/tcld/services"
@@ -61,7 +62,7 @@ type (
 		loginService services.LoginService
 	}
 
-	OauthDeviceCodeResponse struct {
+	OAuthDeviceCodeResponse struct {
 		DeviceCode              string `json:"device_code"`
 		UserCode                string `json:"user_code"`
 		VerificationURI         string `json:"verification_uri"`
@@ -70,7 +71,7 @@ type (
 		Interval                int    `json:"interval"`
 	}
 
-	OauthTokenResponse struct {
+	OAuthTokenResponse struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
 		IDToken      string `json:"id_token"`
@@ -85,9 +86,9 @@ func getTokenConfigPath(ctx *cli.Context) string {
 }
 
 // TODO: support login config on windows
-func loadLoginConfig(ctx *cli.Context) (OauthTokenResponse, error) {
+func loadLoginConfig(ctx *cli.Context) (OAuthTokenResponse, error) {
 
-	tokens := OauthTokenResponse{}
+	tokens := OAuthTokenResponse{}
 	configDir := ctx.Path(ConfigDirFlagName)
 	// Create config dir if it does not exist
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -115,70 +116,93 @@ func loadLoginConfig(ctx *cli.Context) (OauthTokenResponse, error) {
 	return tokens, nil
 }
 
-func getURLFromDomain(domain string) (string, error) {
-	u, err := url.Parse(domain)
+func parseURL(s string) (*url.URL, error) {
+	// Without a scheme, url.Parse would interpret the path as a relative file path.
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = fmt.Sprintf("%s%s", "https://", s)
+	}
+
+	u, err := url.ParseRequestURI(s)
 	if err != nil {
-		return domain, err
+		return nil, err
 	}
+
 	if u.Scheme == "" {
-		return fmt.Sprintf("https://%s", domain), nil
+		u.Scheme = "https"
 	}
-	return domain, nil
+
+	return u, err
 }
 
 func (c *LoginClient) login(ctx *cli.Context, domain string, audience string, clientID string, disablePopUp bool) error {
 	// Get device code
-	oauthDeviceCodeResponse := OauthDeviceCodeResponse{}
-	domain, err := getURLFromDomain(domain)
+	domainURL, err := parseURL(domain)
 	if err != nil {
 		return err
 	}
+
+	codeResp := OAuthDeviceCodeResponse{}
 	if err := postFormRequest(
-		fmt.Sprintf("%s/oauth/device/code", domain),
+		domainURL.JoinPath("oauth", "device", "code").String(),
 		url.Values{
 			"client_id": {clientID},
 			"scope":     {scope},
 			"audience":  {audience},
 		},
-		&oauthDeviceCodeResponse,
+		&codeResp,
 	); err != nil {
 		return err
 	}
 
-	fmt.Printf("Login via this url: %s\n", oauthDeviceCodeResponse.VerificationURIComplete)
+	verificationURL, err := parseURL(codeResp.VerificationURIComplete)
+	if err != nil {
+		return fmt.Errorf("failed to parse verification URL: %w", err)
+	} else if verificationURL.Hostname() != domainURL.Hostname() {
+		// We expect the verification URL to be the same host as the domain URL.
+		// Otherwise the response could have us POST to any arbitrary URL.
+		return fmt.Errorf("domain URL `%s` does not match verification URL `%s` in response", domainURL.Hostname(), verificationURL.Hostname())
+	}
+
+	fmt.Printf("Login via this url: %s\n", verificationURL.String())
 
 	if !disablePopUp {
-		if err := c.loginService.OpenBrowser(oauthDeviceCodeResponse.VerificationURIComplete); err != nil {
+		if err := c.loginService.OpenBrowser(verificationURL.String()); err != nil {
 			fmt.Println("Unable to open browser, please open url manually.")
 		}
 	}
 
+	// According to RFC, we should set a default polling interval if not provided.
+	// https://tools.ietf.org/html/draft-ietf-oauth-device-flow-07#section-3.5
+	if codeResp.Interval == 0 {
+		codeResp.Interval = 10
+	}
+
 	// Get access token
-	oauthTokenResponse := OauthTokenResponse{}
-	for len(oauthTokenResponse.AccessToken) == 0 {
-		time.Sleep(time.Duration(oauthDeviceCodeResponse.Interval) * time.Second)
+	tokenResp := OAuthTokenResponse{}
+	for len(tokenResp.AccessToken) == 0 {
+		time.Sleep(time.Duration(codeResp.Interval) * time.Second)
 
 		if err := postFormRequest(
-			fmt.Sprintf("%s/oauth/token", domain),
+			domainURL.JoinPath("oauth", "token").String(),
 			url.Values{
 				"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
-				"device_code": {oauthDeviceCodeResponse.DeviceCode},
+				"device_code": {codeResp.DeviceCode},
 				"client_id":   {clientID},
 			},
-			&oauthTokenResponse,
+			&tokenResp,
 		); err != nil {
 			return err
 		}
 	}
 
-	oauthTokenResponseJson, err := FormatJson(oauthTokenResponse)
+	tokenRespJson, err := FormatJson(tokenResp)
 	if err != nil {
 		return err
 	}
 	fmt.Println("Successfully logged in!")
 
 	// Save token info locally
-	return c.loginService.WriteToConfigFile(getTokenConfigPath(ctx), oauthTokenResponseJson)
+	return c.loginService.WriteToConfigFile(getTokenConfigPath(ctx), tokenRespJson)
 }
 
 func NewLoginCommand(c *LoginClient) (CommandOut, error) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This adds verification, and default intervals, when receiving the OAuthDeviceCodeResponse.

## Why?
<!-- Tell your future self why have you made these changes -->
Ensures that we perform verification against the auth server's response.

## Checklist
- [x] Added a unit test for if the server passes back an unexpected URL.
- [x] Manually tested the login/logout flow with our environments. Both with and without a scheme specified.
