### PR TITLE
Set max gRPC message size to 50MB

### DIFF
--- a/app/connection.go
+++ b/app/connection.go
@@ -67,6 +67,10 @@ func defaultDialOptions(c *cli.Context, addr *url.URL) ([]grpc.DialOption, error
 	}
 	opts = append(opts, grpc.WithTransportCredentials(transport))
 
+	// Set max message size to 50MB. Messages should never be this large, but useful in a pinch.
+	maxMsgSize := 50 * 1000 * 1000
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize), grpc.MaxCallSendMsgSize(maxMsgSize)))
+
 	return opts, nil
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Set the max gRPC message size to 50MB, which matches the max gRPC size used by Temporal when handling large histories.

## Why?
<!-- Tell your future self why have you made these changes -->
Ensures tcld can still operate when message sizes go above 4MB, even if we should avoid this as much as possible.

## Checklist
N/A