### PR TITLE
Automatically populate version info for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
 COMMIT := $(shell git rev-parse --short HEAD)
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
 APPPKG := $(PROJECT_ROOT)/app
-LINKER_FLAGS := -X $(APPPKG).BuildDate=$(DATE) -X $(APPPKG).Commit=$(COMMIT) -X $(APPPKG).Version=$(TAG)
+LINKER_FLAGS := -X $(APPPKG).MakeVersion=$(TAG)
 
 
 ALL_SRC := $(shell find . -name "*.go")
@@ -19,7 +19,7 @@ COVER_ROOT := ./.coverage
 SUMMARY_COVER_PROFILE := $(COVER_ROOT)/summary_coverprofile.out
 
 tcld:
-	@go build -ldflags "$(LINKER_FLAGS)" -o tcld ./cmd/tcld/*.go
+	@go build -ldflags "$(LINKER_FLAGS)" -o tcld ./cmd/tcld
 
 bins: clean tcld
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 define build
 	@echo "building release for $(1) $(2) $(3)..."
 	@mkdir -p releases
-	@GOOS=$(2) GOARCH=$(3) go build -ldflags "-w $(LINKER_FLAGS)" -o releases/$(1)_$(2)_$(3)$(4) ./cmd/tcld/*.go
+	@GOOS=$(2) GOARCH=$(3) go build -ldflags "-w $(LINKER_FLAGS)" -o releases/$(1)_$(2)_$(3)$(4) ./cmd/tcld
 	@tar -cvzf releases/$(1)_$(2)_$(3).tar.gz releases/$(1)_$(2)_$(3)$(4) &>/dev/null
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ default: clean test bins
 
 TAG_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
 TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
-COMMIT := $(shell git rev-parse --short HEAD)
-DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
+COMMIT := $(shell git rev-parse --short=12 HEAD)
+DATE := $(shell git log -1 --format=%cd --date=iso-strict)
 APPPKG := $(PROJECT_ROOT)/app
-LINKER_FLAGS := -X $(APPPKG).buildDate=$(DATE) -X $(APPPKG).commit=$(COMMIT) -X $(APPPKG).version=$(TAG)
+LINKER_FLAGS := -X $(APPPKG).date=$(DATE) -X $(APPPKG).commit=$(COMMIT) -X $(APPPKG).version=$(TAG)
 
 
 ALL_SRC := $(shell find . -name "*.go")

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || true)
 COMMIT := $(shell git rev-parse --short HEAD)
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
 APPPKG := $(PROJECT_ROOT)/app
-LINKER_FLAGS := -X $(APPPKG).MakeVersion=$(TAG)
+LINKER_FLAGS := -X $(APPPKG).buildDate=$(DATE) -X $(APPPKG).commit=$(COMMIT) -X $(APPPKG).version=$(TAG)
 
 
 ALL_SRC := $(shell find . -name "*.go")

--- a/app/certificates.go
+++ b/app/certificates.go
@@ -493,12 +493,12 @@ func writeCertificates(ctx *cli.Context, typ string, cert, key []byte, certPath,
 	if !yes {
 		return nil
 	}
-	err = ioutil.WriteFile(certPath, cert, 0644)
+	err = os.WriteFile(certPath, cert, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write end-entity certificate: %w", err)
 
 	}
-	err = ioutil.WriteFile(keyPath, key, 0600)
+	err = os.WriteFile(keyPath, key, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write end-entity key: %w", err)
 	}

--- a/app/certificates.go
+++ b/app/certificates.go
@@ -11,7 +11,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"time"
@@ -419,11 +418,11 @@ func NewCertificatesCommand() (CommandOut, error) {
 								return err
 							}
 						}
-						caPem, err := ioutil.ReadFile(ctx.Path(CaCertificateFileFlagName))
+						caPem, err := os.ReadFile(ctx.Path(CaCertificateFileFlagName))
 						if err != nil {
 							return fmt.Errorf("failed to read %s: %w", CaCertificateFileFlagName, err)
 						}
-						caPrivKey, err := ioutil.ReadFile(ctx.Path(caPrivateKeyFileFlagName))
+						caPrivKey, err := os.ReadFile(ctx.Path(caPrivateKeyFileFlagName))
 						if err != nil {
 							return fmt.Errorf("failed to read %s: %w", caPrivateKeyFileFlagName, err)
 						}

--- a/app/connection.go
+++ b/app/connection.go
@@ -40,9 +40,12 @@ func GetServerConnection(c *cli.Context, opts ...grpc.DialOption) (context.Conte
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to dial `%s`: %v", addr.String(), err)
 	}
+
+	buildInfo := NewBuildInfo()
+
 	ctx := context.Background()
-	ctx = metadata.AppendToOutgoingContext(ctx, VersionHeader, getVersion())
-	ctx = metadata.AppendToOutgoingContext(ctx, CommitHeader, Commit)
+	ctx = metadata.AppendToOutgoingContext(ctx, VersionHeader, buildInfo.Version)
+	ctx = metadata.AppendToOutgoingContext(ctx, CommitHeader, buildInfo.Commit)
 	ctx = metadata.AppendToOutgoingContext(ctx, TemporalCloudAPIVersionHeader, TemporalCloudAPIVersion)
 
 	return ctx, conn, nil

--- a/app/connection_test.go
+++ b/app/connection_test.go
@@ -6,8 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"testing"
 
@@ -67,7 +67,7 @@ func (s *ServerConnectionTestSuite) SetupTest() {
 	})
 	require.NoError(s.T(), err)
 
-	err = ioutil.WriteFile(path.Join(s.configDir, tokenFileName), data, 0600)
+	err = os.WriteFile(path.Join(s.configDir, tokenFileName), data, 0600)
 	require.NoError(s.T(), err)
 
 	s.listener = bufconn.Listen(1024 * 1024)

--- a/app/connection_test.go
+++ b/app/connection_test.go
@@ -184,11 +184,12 @@ func (s *ServerConnectionTestSuite) TestGetServerConnection() {
 			s.NoError(err)
 			md := s.testService.receivedMD
 
+			buildInfo := NewBuildInfo()
 			version := getHeaderValue(md, VersionHeader)
-			s.Equal(getVersion(), version)
+			s.Equal(buildInfo.Version, version)
 
 			commit := getHeaderValue(md, CommitHeader)
-			s.Equal(Commit, commit)
+			s.Equal(buildInfo.Commit, commit)
 
 			_, usingAPIKeys := tc.args[APIKeyFlagName]
 			if usingAPIKeys {

--- a/app/feature.go
+++ b/app/feature.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -34,11 +33,11 @@ func getFeatureFlagConfigFilePath() string {
 func getFeatureFlagsFromConfigFile(featureFlagConfigPath string) ([]FeatureFlag, error) {
 	// create config file if not exist
 	if _, err := os.Stat(featureFlagConfigPath); err != nil {
-		if err := ioutil.WriteFile(featureFlagConfigPath, []byte("[]"), 0644); err != nil {
+		if err := os.WriteFile(featureFlagConfigPath, []byte("[]"), 0644); err != nil {
 			return nil, err
 		}
 	}
-	content, err := ioutil.ReadFile(featureFlagConfigPath)
+	content, err := os.ReadFile(featureFlagConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +86,7 @@ func toggleFeatureSaveToPath(feature string, path string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path, output, 0644); err != nil {
+	if err := os.WriteFile(path, output, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/app/login.go
+++ b/app/login.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -104,7 +104,7 @@ func loadLoginConfig(ctx *cli.Context) (OAuthTokenResponse, error) {
 		return tokens, err
 	}
 
-	tokenConfigBytes, err := ioutil.ReadFile(tokenConfig)
+	tokenConfigBytes, err := os.ReadFile(tokenConfig)
 	if err != nil {
 		return tokens, err
 	}
@@ -234,7 +234,7 @@ func postFormRequest(url string, values url.Values, resStruct interface{}) error
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/mail"
+	"os"
 	"strconv"
 	"strings"
 
@@ -353,7 +353,7 @@ func ReadCACerts(ctx *cli.Context) (string, error) {
 	cert := ctx.String(CaCertificateFlagName)
 	if cert == "" {
 		if ctx.Path(CaCertificateFileFlagName) != "" {
-			data, err := ioutil.ReadFile(ctx.Path(CaCertificateFileFlagName))
+			data, err := os.ReadFile(ctx.Path(CaCertificateFileFlagName))
 			if err != nil {
 				return "", err
 			}
@@ -375,7 +375,7 @@ func ReadCertFilters(ctx *cli.Context) ([]byte, error) {
 	var certFilterBytes []byte
 	var err error
 	if len(certFilterFilepath) > 0 {
-		certFilterBytes, err = ioutil.ReadFile(certFilterFilepath)
+		certFilterBytes, err = os.ReadFile(certFilterFilepath)
 		if err != nil {
 			return nil, err
 		}
@@ -752,7 +752,7 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 						var err error
 
 						if fileFlagSet {
-							jsonBytes, err = ioutil.ReadFile(ctx.Path(certificateFilterFileFlagName))
+							jsonBytes, err = os.ReadFile(ctx.Path(certificateFilterFileFlagName))
 							if err != nil {
 								return err
 							}
@@ -826,7 +826,7 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 
 						exportFile := ctx.Path(certificateFilterFileFlagName)
 						if exportFile != "" {
-							if err := ioutil.WriteFile(exportFile, []byte(jsonString), 0644); err != nil {
+							if err := os.WriteFile(exportFile, []byte(jsonString), 0644); err != nil {
 								return err
 							}
 						}
@@ -899,7 +899,7 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 						var err error
 
 						if fileFlagSet {
-							jsonBytes, err = ioutil.ReadFile(ctx.Path(certificateFilterFileFlagName))
+							jsonBytes, err = os.ReadFile(ctx.Path(certificateFilterFileFlagName))
 							if err != nil {
 								return err
 							}

--- a/app/version.go
+++ b/app/version.go
@@ -5,6 +5,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/urfave/cli/v2"
 )
@@ -67,7 +68,11 @@ func NewBuildInfo() BuildInfo {
 		commitInfoStart := len(di.Main.Version) - pseudoVersionCommitInfoLen
 		split := strings.Split(di.Main.Version[commitInfoStart:], "-")
 
-		info.Date = split[0]
+		// Make the time human readable.
+		at, err := time.Parse("20060102150405", split[0])
+		if err == nil {
+			info.Date = at.String()
+		}
 		info.Commit = split[1]
 	} else {
 		// Used when built directly from a branch with `go build`.

--- a/app/version.go
+++ b/app/version.go
@@ -42,9 +42,11 @@ func NewBuildInfo() BuildInfo {
 
 	di, ok := debug.ReadBuildInfo()
 	if !ok {
+		fmt.Printf("Failed to read debug info\n")
 		return info
 	}
 
+	fmt.Printf("di.Main.Version = %s, MakeVersion = %s\n", di.Main.Version, MakeVersion)
 	if semver.IsValid(di.Main.Version) {
 		info.Version = strings.Split(semver.Canonical(di.Main.Version), "-")[0]
 

--- a/app/version.go
+++ b/app/version.go
@@ -71,7 +71,7 @@ func NewBuildInfo() BuildInfo {
 		// Make the time human readable.
 		at, err := time.Parse("20060102150405", split[0])
 		if err == nil {
-			info.Date = at.String()
+			info.Date = at.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
 		info.Commit = split[1]
 	} else {

--- a/app/version.go
+++ b/app/version.go
@@ -59,7 +59,7 @@ func NewBuildInfo() BuildInfo {
 		fmt.Printf("Failed to read debug info\n")
 		return BuildInfo{}
 	}
-	info.Version = di.Main.Version
+	info.Version = strings.SplitAfterN(di.Main.Version, ".", 4)[0]
 
 	if len(di.Main.Version) >= pseudoVersionMinLen {
 		// Used when compiled with `go install`.

--- a/app/version.go
+++ b/app/version.go
@@ -1,16 +1,30 @@
 package app
 
-import "github.com/urfave/cli/v2"
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	"golang.org/x/mod/semver"
+)
 
 const (
-	DefaultVersion = "v0.13.0"
+	pseudoVersionMinLen        = len("vX.0.0-yyyymmddhhmmss-abcdefabcdef")
+	pseudoVersionCommitInfoLen = len("yyyymmddhhmmss-abcdefabcdef")
 )
 
 var (
-	BuildDate string
-	Commit    string
-	Version   string
+	MakeVersion string
 )
+
+type BuildInfo struct {
+	Commit     string
+	CommitTime time.Time
+	Version    string
+}
 
 func NewVersionCommand() (CommandOut, error) {
 	return CommandOut{Command: &cli.Command{
@@ -18,23 +32,58 @@ func NewVersionCommand() (CommandOut, error) {
 		Usage:   "Version information",
 		Aliases: []string{"v"},
 		Action: func(c *cli.Context) error {
-			return PrintObj(&struct {
-				BuildDate string
-				Commit    string
-				Version   string
-			}{
-				BuildDate: BuildDate,
-				Commit:    Commit,
-				Version:   getVersion(),
-			})
+			return PrintObj(NewBuildInfo())
 		},
 	}}, nil
 }
 
-func getVersion() string {
-	version := Version
-	if len(version) == 0 {
-		version = DefaultVersion
+func NewBuildInfo() BuildInfo {
+	var info BuildInfo
+
+	di, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
 	}
-	return version
+
+	if semver.IsValid(di.Main.Version) {
+		info.Version = strings.Split(semver.Canonical(di.Main.Version), "-")[0]
+
+		// See https://go.dev/ref/mod#pseudo-versions for more info on the expected string format
+		// when the binary is compiled with go install. We always expect to hit this path if
+		// di.Main.Version is a valid semver.
+		if len(di.Main.Version) >= pseudoVersionMinLen {
+			commitInfoStart := len(di.Main.Version) - pseudoVersionCommitInfoLen
+			split := strings.Split(di.Main.Version[commitInfoStart:], "-")
+			info.Commit = split[1]
+
+			at, err := time.Parse("20060102150405", split[0])
+			if err == nil {
+				info.CommitTime = at
+			}
+
+			return info
+		}
+	} else {
+		info.Version = MakeVersion
+	}
+
+	// Developer build, pull extra info from vcs.
+	var hash, modified string
+
+	for _, setting := range di.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			hash = setting.Value
+		case "vcs.modified":
+			if v, err := strconv.ParseBool(setting.Value); err == nil && v {
+				modified = "-modified"
+			}
+		case "vcs.time":
+			info.CommitTime, _ = time.Parse(time.RFC3339, setting.Value)
+		}
+	}
+
+	info.Commit = fmt.Sprintf("%s%s", hash, modified)
+
+	return info
 }

--- a/app/version.go
+++ b/app/version.go
@@ -5,10 +5,8 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/urfave/cli/v2"
-	"golang.org/x/mod/semver"
 )
 
 const (
@@ -17,13 +15,15 @@ const (
 )
 
 var (
-	MakeVersion string
+	date    string
+	commit  string
+	version string
 )
 
 type BuildInfo struct {
-	Commit     string
-	CommitTime time.Time
-	Version    string
+	Date    string // build time or commit time.
+	Commit  string
+	Version string
 }
 
 func NewVersionCommand() (CommandOut, error) {
@@ -37,55 +37,55 @@ func NewVersionCommand() (CommandOut, error) {
 	}}, nil
 }
 
+// NewBuildInfo will populate build info, to make debugging API errors easier,
+// in the three scenarios a user can install tcld:
+//  1. Installed via the makefile or via brew.
+//  2. Installed via `go install`.
+//  3. Compiled on a branch via `go build ./cmd/tcld`
 func NewBuildInfo() BuildInfo {
+	if len(version) > 0 {
+		// Used when built with make or installed with brew.
+		return BuildInfo{
+			Date:    date,
+			Commit:  commit,
+			Version: version,
+		}
+	}
+
 	var info BuildInfo
 
 	di, ok := debug.ReadBuildInfo()
 	if !ok {
 		fmt.Printf("Failed to read debug info\n")
-		return info
+		return BuildInfo{}
 	}
+	info.Version = di.Main.Version
 
-	fmt.Printf("di.Main.Version = %s, MakeVersion = %s\n", di.Main.Version, MakeVersion)
-	if semver.IsValid(di.Main.Version) {
-		info.Version = strings.Split(semver.Canonical(di.Main.Version), "-")[0]
-
+	if len(di.Main.Version) >= pseudoVersionMinLen {
+		// Used when compiled with `go install`.
 		// See https://go.dev/ref/mod#pseudo-versions for more info on the expected string format
-		// when the binary is compiled with go install. We always expect to hit this path if
-		// di.Main.Version is a valid semver.
-		if len(di.Main.Version) >= pseudoVersionMinLen {
-			commitInfoStart := len(di.Main.Version) - pseudoVersionCommitInfoLen
-			split := strings.Split(di.Main.Version[commitInfoStart:], "-")
-			info.Commit = split[1]
+		commitInfoStart := len(di.Main.Version) - pseudoVersionCommitInfoLen
+		split := strings.Split(di.Main.Version[commitInfoStart:], "-")
 
-			at, err := time.Parse("20060102150405", split[0])
-			if err == nil {
-				info.CommitTime = at
-			}
-
-			return info
-		}
+		info.Date = split[0]
+		info.Commit = split[1]
 	} else {
-		info.Version = MakeVersion
-	}
-
-	// Developer build, pull extra info from vcs.
-	var hash, modified string
-
-	for _, setting := range di.Settings {
-		switch setting.Key {
-		case "vcs.revision":
-			hash = setting.Value
-		case "vcs.modified":
-			if v, err := strconv.ParseBool(setting.Value); err == nil && v {
-				modified = "-modified"
+		// Used when built directly from a branch with `go build`.
+		var hash, modified string
+		for _, setting := range di.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				hash = setting.Value
+			case "vcs.modified":
+				if v, err := strconv.ParseBool(setting.Value); err == nil && v {
+					modified = "-modified"
+				}
+			case "vcs.time":
+				info.Date = setting.Value
 			}
-		case "vcs.time":
-			info.CommitTime, _ = time.Parse(time.RFC3339, setting.Value)
 		}
+		info.Commit = fmt.Sprintf("%s%s", hash, modified)
 	}
-
-	info.Commit = fmt.Sprintf("%s%s", hash, modified)
 
 	return info
 }

--- a/app/version.go
+++ b/app/version.go
@@ -59,7 +59,7 @@ func NewBuildInfo() BuildInfo {
 		fmt.Printf("Failed to read debug info\n")
 		return BuildInfo{}
 	}
-	info.Version = strings.SplitAfterN(di.Main.Version, ".", 4)[0]
+	info.Version = di.Main.Version
 
 	if len(di.Main.Version) >= pseudoVersionMinLen {
 		// Used when compiled with `go install`.

--- a/app/version.go
+++ b/app/version.go
@@ -52,15 +52,15 @@ func NewBuildInfo() BuildInfo {
 		}
 	}
 
-	var info BuildInfo
-
 	di, ok := debug.ReadBuildInfo()
 	if !ok {
 		fmt.Printf("Failed to read debug info\n")
 		return BuildInfo{}
 	}
-	info.Version = di.Main.Version
 
+	info := BuildInfo{
+		Version: di.Main.Version,
+	}
 	if len(di.Main.Version) >= pseudoVersionMinLen {
 		// Used when compiled with `go install`.
 		// See https://go.dev/ref/mod#pseudo-versions for more info on the expected string format

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,19 @@
 module github.com/temporalio/tcld
 
-go 1.18
+go 1.20
 
 require (
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
+	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.25.3
 	go.uber.org/fx v1.19.2
 	go.uber.org/multierr v1.6.0
+	golang.org/x/mod v0.8.0
 	google.golang.org/grpc v1.54.0
 )
 
@@ -20,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/leodido/go-urn v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/services/loginservice.go
+++ b/services/loginservice.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -41,7 +40,7 @@ func (c *loginService) OpenBrowser(url string) error {
 
 func (c *loginService) WriteToConfigFile(configPath string, data string) error {
 	// Write file as 0600 since it contains private keys.
-	return ioutil.WriteFile(configPath, []byte(data), 0600)
+	return os.WriteFile(configPath, []byte(data), 0600)
 }
 
 func (c *loginService) DeleteConfigFile(configPath string) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR --> 
This uses a combination of the DebugBuildInfo and pseudo version to ensure that we have build information both when:
- The application is built from the Makefile locally.
- The application is built with standard Go tooling, like `go install github.com/temporalio/tcld/cmd/tcld`.
- The application is installed via brew.

Part of this is updating past Go 1.18 for all the new niceness around DebugBuildInfo. Go mod tidy was also ran.

Note, that the Go behaviour is to increment the patch version when you are using an unreleased build from `go install`. You can see this in the checklist where `go install` refers to `v0.13.1` (because it is not the v0.13.0 version) but the makefile refers to `v0.13.0` (even though it is not really the v0.13.0 version).

## Why?
<!-- Tell your future self why have you made these changes -->
Now we do not have to manually update the version with releases.

## Checklist
- [x] Tested the binary from a `go install github.com/temporalio/tcld/cmd/tcld@tszucs/embed-version`:
```
❯ go install github.com/temporalio/tcld/cmd/tcld@tszucs/embed-version
go: downloading github.com/temporalio/tcld v0.13.1-0.20230830001508-132e34e4954e

❯ tcld version
{
    "Date": "2023-08-30T00:15:08.000Z",
    "Commit": "132e34e4954e",
    "Version": "v0.13.1-0.20230830001508-132e34e4954e"
}
```
- [x] Tested the binary from a `clean tcld`:
```
❯ make clean tcld

❯ ./tcld version
{
    "Date": "2023-08-29T17:15:08-07:00",
    "Commit": "132e34e4954e",
    "Version": "v0.13.1-embed-version-test"
}
```
- [x] Tested a pre-released version with the brew changes at https://github.com/temporalio/homebrew-brew/pull/16:
```
❯ brew reinstall  --build-from-source ./tcld.rb
==> Fetching tcld
==> Cloning https://github.com/temporalio/tcld.git
Updating /Users/tszucs/Library/Caches/Homebrew/tcld--git
From github.com:temporalio/tcld
 * [new tag]         v0.13.1-embed-version-test -> v0.13.1-embed-version-test
==> Checking out tag v0.13.1-embed-version-test
HEAD is now at 132e34e Print as ISO timestamp
HEAD is now at 132e34e Print as ISO timestamp
==> Reinstalling tcld
==> go build -ldflags=-s -w -X github.com/temporalio/tcld/app.version=v0.13.1 -X github.com/temporalio/tcld/app.commit=132e34e4954e -X github.com/temporalio/tcld/app.date=2023-08-30T00:15:08Z -o /opt/homebrew/Cellar/tcld/0.13.1/bin/tcld ./cmd/tcld
🍺  /opt/homebrew/Cellar/tcld/0.13.1: 5 files, 15.6MB, built in 2 seconds
==> Running `brew cleanup tcld`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/tszucs/Library/Caches/Homebrew/tcld--0.13.1... (271.3KB)

❯ /opt/hombrew/Cellar/tcld/0.13.1/bin/tcld version
{
    "Date": "2023-08-30T00:15:08Z",
    "Commit": "132e34e4954e",
    "Version": "v0.13.1"
}
```
