### PR TITLE
Use build metadata instead of pre-release version for DefaultVersionString

### DIFF
--- a/app/version.go
+++ b/app/version.go
@@ -19,8 +19,8 @@ const (
 
 	// DefaultVersionString is the version which is sent over if no version was available.
 	// This can happen if a user builds the latest main branch, as the version string provided
-	// to us from Go tooling is `(devel)`
-	DefaultVersionString = MinSupportedVersion + "-no-version-available"
+	// to us from Go tooling is `(devel)`.
+	DefaultVersionString = MinSupportedVersion + "+no-version-available"
 
 	pseudoVersionMinLen        = len("vX.0.0-yyyymmddhhmmss-abcdefabcdef")
 	pseudoVersionCommitInfoLen = len("yyyymmddhhmmss-abcdefabcdef")


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Uses build metadata instead of a pre-release version for our DefaultVersionString.

## Why?
<!-- Tell your future self why have you made these changes --> 
Pre-release versions are parsed as less than a version without pre-release `-` tags in semver.

## Checklist

- [x] Checked version string and tried using tcld to verify that the request does not return a version issue:
```
❯ ./tcld version
{
    "Date": "2023-09-07T19:49:07Z",
    "Commit": "cee87229532d599ede057f074089de979e6c0338-modified",
    "Version": "v0.1.3+no-version-available"
}

❯ ./tcld user get --user-email <some email>
... user details ...
```