### PR TITLE
Adds `tcld account list-regions` command

### DIFF
--- a/app/account.go
+++ b/app/account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/temporalio/tcld/protogen/api/account/v1"
 	"github.com/temporalio/tcld/protogen/api/accountservice/v1"
@@ -14,6 +15,11 @@ import (
 type AccountClient struct {
 	client accountservice.AccountServiceClient
 	ctx    context.Context
+}
+
+type regionInfo struct {
+	CloudProviderRegion string
+	CloudProvider       string
 }
 
 func NewAccountClient(ctx context.Context, conn *grpc.ClientConn) *AccountClient {
@@ -45,6 +51,31 @@ func (c *AccountClient) getAccount() (*account.Account, error) {
 	}
 
 	return res.Account, nil
+}
+
+func (c *AccountClient) listRegions() ([]regionInfo, error) {
+	resp, err := c.client.GetRegions(c.ctx, &accountservice.GetRegionsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get regions: %w", err)
+	}
+
+	var regions []regionInfo
+	for _, r := range resp.Regions {
+		regions = append(regions, regionInfo{
+			CloudProviderRegion: r.GetName(),
+			CloudProvider:       r.GetCloudProvider(),
+		})
+	}
+
+	sort.SliceStable(regions, func(i, j int) bool {
+		if regions[i].CloudProvider < regions[j].CloudProvider {
+			return true
+		}
+
+		return regions[i].CloudProviderRegion < regions[j].CloudProviderRegion
+	})
+
+	return regions, nil
 }
 
 func (c *AccountClient) updateAccount(ctx *cli.Context, a *account.Account) error {
@@ -105,6 +136,18 @@ func NewAccountCommand(getAccountClientFn GetAccountClientFn) (CommandOut, error
 							return err
 						}
 						return PrintProto(n)
+					},
+				},
+				{
+					Name:    "list-regions",
+					Usage:   "Lists all regions where the account can provision namespaces",
+					Aliases: []string{"l"},
+					Action: func(ctx *cli.Context) error {
+						regionInfos, err := c.listRegions()
+						if err != nil {
+							return err
+						}
+						return PrintObj(regionInfos)
 					},
 				},
 				{

--- a/app/account_test.go
+++ b/app/account_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/temporalio/tcld/protogen/api/account/v1"
 	"github.com/temporalio/tcld/protogen/api/accountservice/v1"
+	"github.com/temporalio/tcld/protogen/api/common/v1"
 	"github.com/temporalio/tcld/protogen/api/request/v1"
 	accountservicemock "github.com/temporalio/tcld/protogen/apimock/accountservice/v1"
 	"github.com/urfave/cli/v2"
@@ -70,6 +71,18 @@ func (s *AccountTestSuite) TestGet() {
 		},
 	}, nil).Times(1)
 	s.NoError(s.RunCmd("account", "get"))
+}
+
+func (s *AccountTestSuite) TestListRegions() {
+	s.mockService.EXPECT().GetRegions(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+	s.Error(s.RunCmd("account", "list-regions"))
+
+	s.mockService.EXPECT().GetRegions(gomock.Any(), gomock.Any()).Return(&accountservice.GetRegionsResponse{
+		Regions: []*common.Region{
+			{CloudProvider: "aws", Name: "us-west-2"},
+		},
+	}, nil).Times(1)
+	s.NoError(s.RunCmd("account", "list-regions"))
 }
 
 func (s *AccountTestSuite) TestEnable() {

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -47,20 +47,7 @@ var (
 		Usage:   "The fingerprint of to the ca certificate",
 		Aliases: []string{"fp"},
 	}
-	namespaceRegions = []string{
-		"ap-northeast-1",
-		"ap-south-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"ca-central-1",
-		"eu-central-1",
-		"eu-west-1",
-		"eu-west-2",
-		"sa-east-1",
-		"us-east-1",
-		"us-east-2",
-		"us-west-2",
-	}
+
 	sinkNameFlag = &cli.StringFlag{
 		Name:     "sink-name",
 		Usage:    "Provide a name for the export sink",
@@ -407,7 +394,7 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 				},
 				&cli.StringFlag{
 					Name:     namespaceRegionFlagName,
-					Usage:    fmt.Sprintf("Create namespace in this region; valid regions are: %v", namespaceRegions),
+					Usage:    "Create namespace in specified region; see 'tcld account list-regions' to get a list of available regions for your account",
 					Aliases:  []string{"re"},
 					Required: true,
 				},
@@ -449,13 +436,8 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 					Namespace: ctx.String(NamespaceFlagName),
 				}
 
-				// region (required)
-				region := ctx.String(namespaceRegionFlagName)
-				if err := validateNamespaceRegion(region); err != nil {
-					return err
-				}
 				n.Spec = &namespace.NamespaceSpec{
-					Region: region,
+					Region: ctx.String(namespaceRegionFlagName),
 				}
 
 				// certs (required)
@@ -1453,13 +1435,4 @@ func compareCodecSpec(existing, replacement *namespace.CodecServerPropertySpec) 
 	}
 
 	return diff.Diff(string(existingBytes), string(replacementBytes)), nil
-}
-
-func validateNamespaceRegion(region string) error {
-	for _, r := range namespaceRegions {
-		if r == region {
-			return nil
-		}
-	}
-	return fmt.Errorf("namespace region: %s not allowed", region)
 }


### PR DESCRIPTION
- Regions no longer hard-coded (meaning new release not needed for each new region)
- Regions returned take the user's account into context in case there are any restrictions