### PR TITLE
[CLD-1637] support API key duration in days

### DIFF
--- a/app/apikey.go
+++ b/app/apikey.go
@@ -210,7 +210,7 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 							}
 							d, err := parseDuration(expiryPeriod)
 							if err != nil {
-								return fmt.Errorf("failed to parse duration: %v", err)
+								return fmt.Errorf("failed to parse duration: %w", err)
 							}
 							if d == 0 {
 								return fmt.Errorf("no expiry was set")

--- a/app/apikey.go
+++ b/app/apikey.go
@@ -212,6 +212,9 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 							if err != nil {
 								return fmt.Errorf("failed to parse duration: %v", err)
 							}
+							if d == 0 {
+								return fmt.Errorf("no expiry was set")
+							}
 							e := time.Now().UTC().Add(d)
 							expiry = &e
 						}

--- a/app/apikey.go
+++ b/app/apikey.go
@@ -154,7 +154,7 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 						},
 						&cli.StringFlag{
 							Name:    "duration",
-							Usage:   "the duration from now when the apikey will expire, will be ignored if expiry flag is set, example: '30d' or '4d12h",
+							Usage:   "the duration from now when the apikey will expire, will be ignored if expiry flag is set, examples: '2.5y', '30d', '4d12h'",
 							Aliases: []string{"d"},
 						},
 						&cli.TimestampFlag{
@@ -177,7 +177,7 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 								return fmt.Errorf("failed to parse duration: %w", err)
 							}
 							if d <= 0 {
-								return fmt.Errorf("expiry must be positive: %s", expiryPeriod)
+								return fmt.Errorf("expiration must be positive: %s", expiryPeriod)
 							}
 							e := time.Now().UTC().Add(d)
 							expiry = &e

--- a/app/apikey.go
+++ b/app/apikey.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -136,7 +135,7 @@ func parseDuration(s string) (time.Duration, error) {
 			return d, fmt.Errorf("time: invalid duration \"%s\"", s)
 		}
 		if days < 0 {
-			return d, errors.New("expiration cannot be negative")
+			return d, fmt.Errorf("expiration cannot be negative")
 		}
 		// note: this calculation is _technically_ incorrect,
 		// due to daylight savings time zone transitions.
@@ -153,7 +152,7 @@ func parseDuration(s string) (time.Duration, error) {
 		return d, err
 	}
 	if pd < 0 {
-		return d, errors.New("expiration cannot be negative")
+		return d, fmt.Errorf("expiration cannot be negative")
 	}
 	d += pd
 	return d, nil
@@ -213,7 +212,7 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 								return fmt.Errorf("failed to parse duration: %w", err)
 							}
 							if d == 0 {
-								return fmt.Errorf("no expiry was set")
+								return fmt.Errorf("expiration cannot be zero")
 							}
 							e := time.Now().UTC().Add(d)
 							expiry = &e

--- a/app/apikey.go
+++ b/app/apikey.go
@@ -132,10 +132,10 @@ func parseDuration(s string) (time.Duration, error) {
 	if len(parts) == 2 {
 		days, err := strconv.ParseInt(parts[0], 10, 32)
 		if err != nil {
-			return d, fmt.Errorf("time: invalid duration \"%s\"", s)
+			return 0, fmt.Errorf("time: invalid duration \"%s\"", s)
 		}
 		if days < 0 {
-			return d, fmt.Errorf("expiration cannot be negative")
+			return 0, fmt.Errorf("expiration cannot be negative")
 		}
 		// note: this calculation is _technically_ incorrect,
 		// due to daylight savings time zone transitions.
@@ -149,10 +149,10 @@ func parseDuration(s string) (time.Duration, error) {
 	}
 	pd, err := time.ParseDuration(durationString)
 	if err != nil {
-		return d, err
+		return 0, err
 	}
 	if pd < 0 {
-		return d, fmt.Errorf("expiration cannot be negative")
+		return 0, fmt.Errorf("expiration cannot be negative")
 	}
 	d += pd
 	return d, nil

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -34,8 +34,8 @@ func TestParseDuration(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			arg:  "30d",
-			want: 30 * 24 * time.Hour,
+			arg:  "730d",
+			want: 730 * 24 * time.Hour,
 		},
 		{
 			arg:     "-2d",

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -43,7 +43,7 @@ func TestParseDuration(t *testing.T) {
 		},
 		{
 			arg:  "2d12h30m",
-			want: 2*24*time.Hour + 12*time.Hour + 30*time.Minute,
+			want: 60*time.Hour + 30*time.Minute,
 		},
 		{
 			arg:     "-2d12h30m",
@@ -62,12 +62,12 @@ func TestParseDuration(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			arg:     "2d10h4d30m",
+			arg:     "2d10h30m4d",
 			wantErr: true,
 		},
 		{
-			// technically valid due to 'time.ParseDuration', but
-			// note that we require 'd' to come first (if present)
+			// technically valid due to the behaviour of time.ParseDuration(),
+			// but note that we require 'd' to come first (if present)
 			arg:  "2d55s20m10h",
 			want: 58*time.Hour + 20*time.Minute + 55*time.Second,
 		},

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -15,78 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func TestParseDuration(t *testing.T) {
-	tests := []struct {
-		arg     string
-		want    time.Duration
-		wantErr bool
-	}{
-		{
-			arg:  "12h",
-			want: 12 * time.Hour,
-		},
-		{
-			arg:     "-24h",
-			wantErr: true,
-		},
-		{
-			arg:     "d",
-			wantErr: true,
-		},
-		{
-			arg:  "0d24h",
-			want: 24 * time.Hour,
-		},
-		{
-			arg:  "730d",
-			want: 730 * 24 * time.Hour,
-		},
-		{
-			arg:     "-2d",
-			wantErr: true,
-		},
-		{
-			arg:  "2d12h30m",
-			want: 60*time.Hour + 30*time.Minute,
-		},
-		{
-			arg:     "-2d12h30m",
-			wantErr: true,
-		},
-		{
-			arg:     "2d-12h30m",
-			wantErr: true,
-		},
-		{
-			arg:     "abcd12h30m",
-			wantErr: true,
-		},
-		{
-			arg:     "2dddd",
-			wantErr: true,
-		},
-		{
-			arg:     "2d10h30m4d",
-			wantErr: true,
-		},
-		{
-			// technically valid due to the behaviour of time.ParseDuration(),
-			// but note that we require 'd' to come first (if present)
-			arg:  "2d55s20m10h",
-			want: 58*time.Hour + 20*time.Minute + 55*time.Second,
-		},
-	}
-	for _, test := range tests {
-		if got, err := parseDuration(test.arg); err != nil {
-			if !test.wantErr {
-				t.Fatalf("unexpected error: %v, input: %s", err, test.arg)
-			}
-		} else if got != test.want {
-			t.Fatalf("expected: %s, got: %s", test.want, got)
-		}
-	}
-}
-
 func TestAPIKey(t *testing.T) {
 	suite.Run(t, new(APIKeyTestSuite))
 }
@@ -167,7 +95,7 @@ func (s *APIKeyTestSuite) TestCreate() {
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "-24h"))
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "0d"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(nil, errors.New("create apikey error")).Times(1)
-	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "1h"))
+	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "30d"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(&authservice.CreateAPIKeyResponse{
 		Id:        "id1",
 		SecretKey: "secret1",
@@ -175,7 +103,7 @@ func (s *APIKeyTestSuite) TestCreate() {
 			RequestId: "rid",
 		},
 	}, nil).Times(1)
-	s.NoError(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "1h"))
+	s.NoError(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "30d"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(&authservice.CreateAPIKeyResponse{
 		Id:        "id1",
 		SecretKey: "secret1",

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -34,6 +34,10 @@ func TestParseDuration(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			arg:  "0d24h",
+			want: 24 * time.Hour,
+		},
+		{
 			arg:  "730d",
 			want: 730 * 24 * time.Hour,
 		},
@@ -161,6 +165,7 @@ func (s *APIKeyTestSuite) TestCreate() {
 	s.Error(s.RunCmd("apikey", "create"))
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1"))
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "-24h"))
+	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "0d"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(nil, errors.New("create apikey error")).Times(1)
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "1h"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(&authservice.CreateAPIKeyResponse{

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -15,6 +15,74 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		arg     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			arg:  "12h",
+			want: 12 * time.Hour,
+		},
+		{
+			arg:     "-24h",
+			wantErr: true,
+		},
+		{
+			arg:     "d",
+			wantErr: true,
+		},
+		{
+			arg:  "30d",
+			want: 30 * 24 * time.Hour,
+		},
+		{
+			arg:     "-2d",
+			wantErr: true,
+		},
+		{
+			arg:  "2d12h30m",
+			want: 2*24*time.Hour + 12*time.Hour + 30*time.Minute,
+		},
+		{
+			arg:     "-2d12h30m",
+			wantErr: true,
+		},
+		{
+			arg:     "2d-12h30m",
+			wantErr: true,
+		},
+		{
+			arg:     "abcd12h30m",
+			wantErr: true,
+		},
+		{
+			arg:     "2dddd",
+			wantErr: true,
+		},
+		{
+			arg:     "2d10h4d30m",
+			wantErr: true,
+		},
+		{
+			// technically valid due to 'time.ParseDuration', but
+			// note that we require 'd' to come first (if present)
+			arg:  "2d55s20m10h",
+			want: 58*time.Hour + 20*time.Minute + 55*time.Second,
+		},
+	}
+	for _, test := range tests {
+		if got, err := parseDuration(test.arg); err != nil {
+			if !test.wantErr {
+				t.Fatalf("unexpected error: %v, input: %s", err, test.arg)
+			}
+		} else if got != test.want {
+			t.Fatalf("expected: %s, got: %s", test.want, got)
+		}
+	}
+}
+
 func TestAPIKey(t *testing.T) {
 	suite.Run(t, new(APIKeyTestSuite))
 }
@@ -92,6 +160,7 @@ func (s *APIKeyTestSuite) TestList() {
 func (s *APIKeyTestSuite) TestCreate() {
 	s.Error(s.RunCmd("apikey", "create"))
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1"))
+	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "-24h"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(nil, errors.New("create apikey error")).Times(1)
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1", "--duration", "1h"))
 	s.mockAuthService.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).Return(&authservice.CreateAPIKeyResponse{


### PR DESCRIPTION
**Problem**
The `duration` flag for API key creation uses [time.ParseDuration](https://pkg.go.dev/time#ParseDuration), which only supports strings of the form `2h45m` (where hour is the highest level of granularity). However, the UI for API key creation only supports days, which is a mismatch in UX.

**Solution**
Switch to `utils.ParseDuration` which extends `time.ParseDuration` to accept years and days.

**Result**
Clients can specify API key expiration in days.