### PR TITLE
Add ff back for export

### DIFF
--- a/app/feature.go
+++ b/app/feature.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
+	ExportFeatureFlag   = "enable-export"
 	GCPSinkFeatureFlag  = "enable-gcp-sink"
 	featureflagFileName = "feature.json"
 )
 
-var supportFeatureFlags = []string{GCPSinkFeatureFlag}
+var supportFeatureFlags = []string{GCPSinkFeatureFlag, ExportFeatureFlag}
 
 type FeatureFlag struct {
 	Name  string `json:"Name"`
@@ -118,6 +119,14 @@ func NewFeatureCommand() (CommandOut, error) {
 			Usage:   "feature commands",
 			Hidden:  true,
 			Subcommands: []*cli.Command{
+				{
+					Name:    "toggle-export",
+					Aliases: []string{"te"},
+					Usage:   "switch export on/off",
+					Action: func(c *cli.Context) error {
+						return toggleFeature(ExportFeatureFlag)
+					},
+				},
 				{
 					Name:    "toggle-gcp-sink",
 					Aliases: []string{"tgs"},

--- a/app/namespace.go
+++ b/app/namespace.go
@@ -1648,16 +1648,19 @@ func NewNamespaceCommand(getNamespaceClientFn GetNamespaceClientFn) (CommandOut,
 		},
 	}
 
-	exportS3Commands.Subcommands = append(exportS3Commands.Subcommands, exportGeneralCommands...)
-	exportCommand.Subcommands = append(exportCommand.Subcommands, exportS3Commands)
+	// TODO: remove Export sink feature flag check when out of pre-release
+	if IsFeatureEnabled(ExportFeatureFlag) {
+		exportS3Commands.Subcommands = append(exportS3Commands.Subcommands, exportGeneralCommands...)
+		exportCommand.Subcommands = append(exportCommand.Subcommands, exportS3Commands)
 
-	// TODO: remove GCP sink feature flag check when out of pre-release
-	if IsFeatureEnabled(GCPSinkFeatureFlag) {
-		exportGCSCommands.Subcommands = append(exportGCSCommands.Subcommands, exportGeneralCommands...)
-		exportCommand.Subcommands = append(exportCommand.Subcommands, exportGCSCommands)
+		// TODO: remove GCP sink feature flag check when out of pre-release
+		if IsFeatureEnabled(GCPSinkFeatureFlag) {
+			exportGCSCommands.Subcommands = append(exportGCSCommands.Subcommands, exportGeneralCommands...)
+			exportCommand.Subcommands = append(exportCommand.Subcommands, exportGCSCommands)
+		}
+
+		subCommands = append(subCommands, exportCommand)
 	}
-
-	subCommands = append(subCommands, exportCommand)
 
 	command := &cli.Command{
 		Name:    "namespace",

--- a/app/namespace_test.go
+++ b/app/namespace_test.go
@@ -46,6 +46,9 @@ func (s *NamespaceTestSuite) SetupTest() {
 		},
 	}
 
+	err = s.RunCmd("feature", "toggle-export")
+	s.Require().NoError(err)
+
 	err = s.RunCmd("feature", "toggle-gcp-sink")
 	s.Require().NoError(err)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Let's add the export feature toggle back. 

In order to use GCP sink, user has to have export and gcp 2 feature toggle. We expect Export Public Preview should be before GCP Sink preview. 


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
