### PR TITLE
feat: add api key owner listing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ tcld apikey create --name <api-key-name> --description <api-key-description> --d
 ```
 tcld apikey list
 ```
+
+### List API Keys for a specific account (ServiceAccount or User):
+```
+tcld apikey list --owner-id <account-id>
+```
+
 ### Delete an API Key:
 ```
 tcld apikey delete --id <api-key-id>
@@ -75,6 +81,8 @@ tcld apikey enable --id <api-key-id>
 ```
 
 ### Performing an API Key rotation:
+
+#### Current User Specific Rotation
 1. Generate the new API key to rotate to.
 ```
 tcld apikey create --name <api-key-name> --description <api-key-description> --duration <api-key-duration>
@@ -82,6 +90,17 @@ tcld apikey create --name <api-key-name> --description <api-key-description> --d
 2. Update temporal clients to use the new API key and monitor deployments to make sure all old API key usage is gone.
 3. Delete the old API key.
 ``` 
+tcld apikey delete --id <api-key-id>
+```
+
+#### Service Account Specific Rotation
+1. Generate the new API key to rotate to.
+```
+tcld apikey create --name <api-key-name> --description <api-key-description> --duration <api-key-duration> --service-account-id <service-account-id>
+```
+2. Update temporal clients to use the new API key and monitor deployments to make sure all old API key usage is gone.
+3. Delete the old API key.
+```
 tcld apikey delete --id <api-key-id>
 ```
 

--- a/app/apikey.go
+++ b/app/apikey.go
@@ -12,6 +12,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	ownerIDFlagName = "owner-id"
+)
+
 type (
 	APIKeyClient struct {
 		client authservice.AuthServiceClient
@@ -85,12 +89,13 @@ func (s *APIKeyClient) createServiceAccountAPIKey(
 	return PrintProto(resp)
 }
 
-func (s *APIKeyClient) listAPIKey() error {
+func (s *APIKeyClient) listAPIKey(ownerId string) error {
 
 	totalRes := &authservice.GetAPIKeysResponse{}
 	pageToken := ""
 	for {
 		resp, err := s.client.GetAPIKeys(s.ctx, &authservice.GetAPIKeysRequest{
+			OwnerId:   ownerId,
 			PageToken: pageToken,
 		})
 		if err != nil {
@@ -258,9 +263,17 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 					Name:    "list",
 					Usage:   "List apikeys",
 					Aliases: []string{"l"},
-					Flags:   []cli.Flag{},
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    ownerIDFlagName,
+							Usage:   "The owner id of the API Keys to list",
+							Aliases: []string{"o"},
+						},
+					},
 					Action: func(ctx *cli.Context) error {
-						return c.listAPIKey()
+						return c.listAPIKey(
+							ctx.String(ownerIDFlagName),
+						)
 					},
 				},
 				{

--- a/app/apikey_test.go
+++ b/app/apikey_test.go
@@ -89,6 +89,17 @@ func (s *APIKeyTestSuite) TestList() {
 	s.NoError(s.RunCmd("apikey", "list"))
 }
 
+func (s *APIKeyTestSuite) TestOwnerIdList() {
+	s.mockAuthService.EXPECT().GetAPIKeys(gomock.Any(), gomock.Any()).Return(&authservice.GetAPIKeysResponse{
+		ApiKeys: []*auth.APIKey{
+			{
+				Id: "test-apikey-id-1",
+			},
+		},
+	}, nil).Times(1)
+	s.NoError(s.RunCmd("apikey", "list", "--owner-id", "ownerID"))
+}
+
 func (s *APIKeyTestSuite) TestCreate() {
 	s.Error(s.RunCmd("apikey", "create"))
 	s.Error(s.RunCmd("apikey", "create", "--name", "test1"))


### PR DESCRIPTION
fixes #395

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This adds the `--owner-id` flag to the `tcld ak l` command, with a shorthand of `-o`.

## Why?
<!-- Tell your future self why have you made these changes -->
 Given that this will enable passing in ServiceAccount IDs or User IDs, we can better reduce the number of paginated requests being performed for automations that are centered around key rotations, while enabling continued development 

## Checklist
<!--- add/delete as needed --->

1. Closes #395 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I built the command locally and ran it against our cloud instance to great success.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Updated the README for listing API keys and also took liberty to document rotating ServiceAccount keys in the same manner (since the `--si value` flag was undocumented in README).