### PR TITLE
fix bug where setting TEMPORAL_CLOUD_API_KEY interferes with unit tests

### DIFF
--- a/app/connection_test.go
+++ b/app/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -164,6 +165,9 @@ func (s *ServerConnectionTestSuite) TestGetServerConnection() {
 	}
 	for _, tc := range testcases {
 		s.Run(tc.name, func() {
+			// setting the env var unexpectedly interferes with the test.
+			require.NoError(s.T(), os.Unsetenv("TEMPORAL_CLOUD_API_KEY"))
+
 			app, cfgDir := NewTestApp(s.T(), nil, []cli.Flag{
 				ServerFlag,
 				ConfigDirFlag,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
fix bug where setting TEMPORAL_CLOUD_API_KEY interferes with unit tests

## Why?
<!-- Tell your future self why have you made these changes -->
https://github.com/temporalio/tcld/issues/349
