### PR TITLE
Fix for auto login

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -67,16 +67,30 @@ func login(ctx *cli.Context, tokenConfig *TokenConfig) (*TokenConfig, error) {
 }
 
 func defaultTokenConfig(ctx *cli.Context) (*TokenConfig, error) {
-	domainURL, err := parseURL(ctx.String(domainFlagName))
+	domainURLStr := ctx.String(domainFlagName)
+	if domainURLStr == "" {
+		domainURLStr = domainFlag.Value
+	}
+	domainURL, err := parseURL(domainURLStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse domain URL: %w", err)
 	}
 
+	audience := ctx.String(audienceFlagName)
+	if audience == "" {
+		audience = audienceFlag.Value
+	}
+
+	clientID := ctx.String(clientIDFlagName)
+	if clientID == "" {
+		clientID = clientIDFlag.Value
+	}
+
 	return &TokenConfig{
-		Audience: ctx.String(audienceFlagName),
+		Audience: audience,
 		Domain:   domainURL.String(),
 		OAuthConfig: oauth2.Config{
-			ClientID: ctx.String("client-id"),
+			ClientID: clientID,
 			Endpoint: oauth2.Endpoint{
 				DeviceAuthURL: domainURL.JoinPath("oauth", "device", "code").String(),
 				TokenURL:      domainURL.JoinPath("oauth", "token").String(),

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -69,6 +69,7 @@ func login(ctx *cli.Context, tokenConfig *TokenConfig) (*TokenConfig, error) {
 func defaultTokenConfig(ctx *cli.Context) (*TokenConfig, error) {
 	domainURLStr := ctx.String(domainFlagName)
 	if domainURLStr == "" {
+		// the domain flag was not set on the command, fallback to the default value set in the flag definition
 		domainURLStr = domainFlag.Value
 	}
 	domainURL, err := parseURL(domainURLStr)
@@ -78,11 +79,13 @@ func defaultTokenConfig(ctx *cli.Context) (*TokenConfig, error) {
 
 	audience := ctx.String(audienceFlagName)
 	if audience == "" {
+		// the audience flag is not set on the command, fallback to the default value set in the flag definition
 		audience = audienceFlag.Value
 	}
 
 	clientID := ctx.String(clientIDFlagName)
 	if clientID == "" {
+		// the clientID flag is not set on the command, fallback to the default value set in the flag definition
 		clientID = clientIDFlag.Value
 	}
 


### PR DESCRIPTION
Fix For:
```
$ tcld n r s -n abhinavtest1.a2dd6 --rd 2
failed to generate default dial options: failed to login: failed to perform device auth: Post "https://oauth/device/code": dial tcp: lookup oauth: no such host
$ tcld login
Login via this url: https://login.tmprl.cloud/activate?user_code=KXMS-ZNFD
Successfully logged in!
$ tcld n r s -n abhinavtest1.a2dd6 --rd 2
{
	"requestStatus": {
		"requestId": "88569f7a-aa91-4e5d-8929-5d6efa05a4aa",
		"state": "InProgress",
		"checkDuration": "10s",
		"operationType": "UpdateNamespace",
		"resourceId": "abhinavtest1.a2dd6",
		"resourceType": "namespace",
		"failureReason": "",
		"startTime": "2024-12-17T14:38:27Z",
		"finishTime": null
	}
}
```