### PR TITLE
feat: allow account role to be set to none

### DIFF
--- a/app/role.go
+++ b/app/role.go
@@ -15,6 +15,10 @@ var (
 	namespaceActionGroups = getNamespaceActionGroups()
 )
 
+const (
+	accountActionGroupNone = "none"
+)
+
 func getAccountActionGroups() []string {
 	var rv []string
 	for n, v := range auth.AccountActionGroup_value {
@@ -63,7 +67,10 @@ func getNamespaceRolesBatch(ctx context.Context, client authservice.AuthServiceC
 	return res.Roles, nil
 }
 
-func getAccountRole(ctx context.Context, client authservice.AuthServiceClient, actionGroup string) (*auth.Role, error) {
+func getAccountRole(ctx context.Context, client authservice.AuthServiceClient, actionGroup string, allowNone bool) (*auth.Role, error) {
+	if allowNone && strings.ToLower(strings.TrimSpace(actionGroup)) == accountActionGroupNone {
+		return nil, nil
+	}
 	ag, err := toAccountActionGroup(actionGroup)
 	if err != nil {
 		return nil, err

--- a/app/user.go
+++ b/app/user.go
@@ -146,7 +146,7 @@ func (c *UserClient) inviteUsers(
 	var roleIDs []string
 
 	// first get the required account role
-	role, err := getAccountRole(c.ctx, c.client, accountRole)
+	role, err := getAccountRole(c.ctx, c.client, accountRole, false)
 	if err != nil {
 		return err
 	}
@@ -257,11 +257,21 @@ func (c *UserClient) setAccountRole(
 		return err
 	}
 	var newRoleIDs []string
-	accountRoleToSet, err := getAccountRole(c.ctx, c.client, accountRole)
+	accountRoleToSet, err := getAccountRole(c.ctx, c.client, accountRole, true)
 	if err != nil {
 		return err
 	}
-	if accountRoleToSet.Spec.AccountRole.ActionGroup == auth.ACCOUNT_ACTION_GROUP_ADMIN {
+	if accountRoleToSet == nil {
+		// Setting account role to none.
+		for _, r := range userRoles {
+			// remove any account roles
+			if r.Type == auth.ROLE_TYPE_PREDEFINED && r.Spec.AccountRole != nil {
+				continue
+			} else {
+				newRoleIDs = append(newRoleIDs, r.Id)
+			}
+		}
+	} else if accountRoleToSet.Spec.AccountRole.ActionGroup == auth.ACCOUNT_ACTION_GROUP_ADMIN {
 		// set the user account admin role
 		y, err := ConfirmPrompt(ctx, "Setting admin role on user. All existing namespace permissions will be replaced, please confirm")
 		if err != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
If a user was added via SCIM, setting their account role to none is valid. The call will fail if the user is not a SCIM user. 

## Why?
<!-- Tell your future self why have you made these changes -->
So user's can have only group derived roles assignments. 

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit test and manual test of SCIM user

