### PR TITLE
expose shell completion generation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -38,6 +38,7 @@ func NewApp(params AppParams) (*cli.App, error) {
 			EnableDebugLogsFlag,
 		},
 		Commands: enabledCommands,
+		EnableBashCompletion: true,
 	}
 
 	return app, nil


### PR DESCRIPTION
## What was changed
expose a hidden `--generate-bash-completion` flag, which produces a stub that `urfave`'s shell autocomplete scripts can use for tab completion.

## Why?
`urfave-v2` supports automatically generating a shell completion stub[^1] for use with their bash[^2] and zsh[^3] completion scripts.

## Checklist

1. How was this tested? built `tcld` and verified that the autocompletion behavior works as-expected
2. Any docs updates needed? I don't think so; this should only be relevant to people packaging this for distribution

---

[^1]: https://cli.urfave.org/v2/examples/bash-completions/
[^2]: https://github.com/urfave/cli/blob/v2-maint/autocomplete/bash_autocomplete
[^3]: https://github.com/urfave/cli/blob/v2-maint/autocomplete/zsh_autocomplete
