### PR TITLE
feat: append or remove ns role on user-group set access

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ The `--namespace-role` flag can be repeated for each namespace role the group sh
 
 The account and namespace roles replace the definition, so any namespace roles omitted will be removed from the group level access.
 
+To add or remove namespace access without specifying all other roles, the `set-access` command also takes in a `--append`(`-a`), or `--remove`(`-r`) flag which will add the given namespace access or remove them. Appending will not change an existing namespace access(it will reject the update) and the account access cannot be changed when either flag is specified.
+
 # Migration Management (Preview)
 
 *The Migration feature is currently in "Preview Release". Customers must be invited to use this feature. Please reach out to Temporal Cloud support for more information.*

--- a/app/user_group.go
+++ b/app/user_group.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,6 +16,8 @@ import (
 const (
 	groupIDFlagName       = "group-id"
 	namespaceRoleFlagName = "namespace-role"
+	appendFlagName        = "append"
+	removeFlagName        = "remove"
 )
 
 type (
@@ -127,29 +130,77 @@ func nsRoleToAccess(role string) (string, *identity.NamespaceAccess) {
 }
 
 // setAccess sets the access for a group using the cloud services API
-func (c *UserGroupClient) setAccess(ctx *cli.Context, groupID string, accountRole string, nsRoles []string) error {
+func (c *UserGroupClient) setAccess(ctx *cli.Context, groupID string,
+	accountRole string, nsRoles []string, appendMode bool, removeMode bool) error {
+	if appendMode && removeMode {
+		return errors.New("Cannot use both append and remove flags")
+	}
+
 	group, err := c.client.GetUserGroup(c.ctx, &cloudsvc.GetUserGroupRequest{
 		GroupId: groupID,
 	})
 	if err != nil {
 		return err
 	}
-	aRole := accountRoleToAccess(accountRole)
-	if aRole == nil {
-		return cli.Exit(fmt.Sprintf("Invalid account role: %s", accountRole), 1)
-	}
-	group.Group.Spec.Access.AccountAccess = aRole
-	if accountRole == "none" {
-		group.Group.Spec.Access.AccountAccess = nil
+
+	// Start with existing namespace accesses if we're appending or removing,
+	// if not appending or removing, set the account role
+	nsAccess := map[string]*identity.NamespaceAccess{}
+	if appendMode || removeMode {
+		// Copy existing namespace accesses
+		for ns, access := range group.Group.Spec.Access.NamespaceAccesses {
+			nsAccess[ns] = access
+		}
+
+		if accountRole != "" {
+			return errors.New("Cannot set account role when appending or removing namespace roles")
+		}
+	} else {
+		aRole := accountRoleToAccess(accountRole)
+		if aRole == nil {
+			return cli.Exit(fmt.Sprintf("Invalid account role: %s", accountRole), 1)
+		}
+		group.Group.Spec.Access.AccountAccess = aRole
+		if accountRole == "none" {
+			group.Group.Spec.Access.AccountAccess = nil
+		}
 	}
 
-	nsAccess := map[string]*identity.NamespaceAccess{}
-	for _, role := range nsRoles {
-		name, access := nsRoleToAccess(role)
-		if access == nil {
-			return cli.Exit(fmt.Sprintf("Invalid namespace role: %s", role), 1)
+	// Handle append flag - add new namespace roles
+	if appendMode {
+		for _, role := range nsRoles {
+			name, access := nsRoleToAccess(role)
+			if access == nil {
+				return cli.Exit(fmt.Sprintf("Invalid namespace role: %s", role), 1)
+			}
+			if nsAccess[name] != nil {
+				return fmt.Errorf("Group already has access to the %s namespace, remove existing access before appending", name)
+			}
+			nsAccess[name] = access
 		}
-		nsAccess[name] = access
+	}
+
+	// Handle remove flag - remove existing namespace roles
+	if removeMode {
+		for _, role := range nsRoles {
+			name, _ := nsRoleToAccess(role)
+			if name == "" {
+				return cli.Exit(fmt.Sprintf("Invalid namespace role: %s", role), 1)
+			}
+			delete(nsAccess, name)
+		}
+	}
+
+	// Handle regular namespace roles (replaces all if no append/remove flags)
+	if !appendMode && !removeMode {
+		nsAccess = map[string]*identity.NamespaceAccess{}
+		for _, role := range nsRoles {
+			name, access := nsRoleToAccess(role)
+			if access == nil {
+				return cli.Exit(fmt.Sprintf("Invalid namespace role: %s", role), 1)
+			}
+			nsAccess[name] = access
+		}
 	}
 
 	group.Group.Spec.Access.NamespaceAccesses = nsAccess
@@ -240,9 +291,19 @@ func NewUserGroupCommand(GetGroupClientFn GetGroupClientFn) (CommandOut, error) 
 							Usage:   "namespace roles",
 							Aliases: []string{"nr"},
 						},
+						&cli.BoolFlag{
+							Name:    appendFlagName,
+							Usage:   "append namespace roles, cannot be used with remove flag, cannot set account role",
+							Aliases: []string{"a"},
+						},
+						&cli.BoolFlag{
+							Name:    removeFlagName,
+							Usage:   "remove namespace roles, cannot be used with append flag, cannot set account role",
+							Aliases: []string{"r"},
+						},
 					},
 					Action: func(ctx *cli.Context) error {
-						return c.setAccess(ctx, ctx.String(groupIDFlagName), ctx.String(accountRoleFlagName), ctx.StringSlice(namespaceRoleFlagName))
+						return c.setAccess(ctx, ctx.String(groupIDFlagName), ctx.String(accountRoleFlagName), ctx.StringSlice(namespaceRoleFlagName), ctx.Bool(appendFlagName), ctx.Bool(removeFlagName))
 					},
 				},
 			},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds append and remove flags for managing user group access which will allow appending or removing specific namespace roles without having to know the all the other namespace roles. It will not allow you to append if there is already a namespace role. 
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->
Ergonomics

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
