### PR TITLE
add tls-server-name override flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -29,6 +29,7 @@ func NewApp(params AppParams) (*cli.App, error) {
 		Usage: "Temporal Cloud cli",
 		Flags: []cli.Flag{
 			ServerFlag,
+			TLSServerNameFlag,
 			ConfigDirFlag,
 			AutoConfirmFlag,
 			IdempotentFlag,

--- a/app/connection.go
+++ b/app/connection.go
@@ -107,9 +107,13 @@ func defaultDialOptions(c *cli.Context, addr *url.URL) ([]grpc.DialOption, error
 		opts = append(opts, grpc.WithPerRPCCredentials(creds))
 	}
 
+	serverName := addr.Hostname()
+	if tlsServerName := c.String(TLSServerNameFlagName); tlsServerName != "" {
+		serverName = tlsServerName
+	}
 	transport := credentials.NewTLS(&tls.Config{
 		MinVersion: tls.VersionTLS12,
-		ServerName: addr.Hostname(),
+		ServerName: serverName,
 	})
 	if c.Bool(InsecureConnectionFlagName) {
 		transport = insecure.NewCredentials()

--- a/app/flags.go
+++ b/app/flags.go
@@ -16,6 +16,7 @@ const (
 	ResourceVersionFlagName    = "resource-version"
 	APIKeyFlagName             = "api-key"
 	InsecureConnectionFlagName = "insecure"
+	TLSServerNameFlagName      = "tls-server-name"
 	EnableDebugLogsFlagName    = "enable-debug-logs"
 	IdempotentFlagName         = "idempotent"
 	AuthenticationFlagCategory = "Authentication:"
@@ -81,6 +82,12 @@ var (
 		// users may be using a service mesh or local proxy, which is insecure locally but uses TLS off the host,
 		// and thus may require the use of this.
 		Hidden: true,
+	}
+	TLSServerNameFlag = &cli.StringFlag{
+		Name:     TLSServerNameFlagName,
+		Usage:    "Override the TLS server name for certificate validation (useful for connecting through proxies)",
+		EnvVars:  []string{"TEMPORAL_CLOUD_TLS_SERVER_NAME"},
+		Category: AuthenticationFlagCategory,
 	}
 	EnableDebugLogsFlag = &cli.BoolFlag{
 		Name:    EnableDebugLogsFlagName,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adding tls-server-name override option similar to temporal cli. 

## Why?
This could be used when customer is behind reverse proxies or vpce endpoints (when private DNS resolution is not supported). 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Tested locally
```
./tcld --server aws-us-west-2.region.tmprl.cloud:443 --tls-server-name saas-api.tmprl.cloud namespace get --namespace gisripa-playground.a2dd6
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
