### PR TITLE
Max duration is 2 years, so make example 1.5 years

### DIFF
--- a/app/apikey.go
+++ b/app/apikey.go
@@ -211,7 +211,7 @@ func NewAPIKeyCommand(getAPIKeyClientFn GetAPIKeyClientFn) (CommandOut, error) {
 						},
 						&cli.StringFlag{
 							Name:    "duration",
-							Usage:   "the duration from now when the apikey will expire, will be ignored if expiry flag is set, examples: '2.5y', '30d', '4d12h'",
+							Usage:   "the duration from now when the apikey will expire, will be ignored if expiry flag is set, examples: '1.5y', '30d', '4d12h'",
 							Aliases: []string{"d"},
 						},
 						&cli.TimestampFlag{


### PR DESCRIPTION
## What was changed
Change example string from 2.5y to 1.5y

## Why?
Because max API key duration is 2 years

## Checklist

1. How was this tested:
Ran locally, confirmed output is fixed and that apikey create command works the same as it did before

2. Any docs updates needed?
No