### PR TITLE
ci: add GoReleaser for pre-compiled binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release Pipeline
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.23'
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - main: ./cmd/tcld
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -w
+      - -X github.com/temporalio/tcld/app.date={{.Date}}
+      - -X github.com/temporalio/tcld/app.commit={{.ShortCommit}}
+      - -X github.com/temporalio/tcld/app.version={{.Tag}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "tcld_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: sha256sums.txt
+  algorithm: sha256


### PR DESCRIPTION
## What was changed

- Added `.goreleaser.yaml` to build pre-compiled binaries for Linux (amd64/arm64), macOS (amd64/arm64), and Windows (amd64)
- Added `.github/workflows/release.yml` to trigger GoReleaser automatically on semver tag pushes (`v*.*.*`)

## Why?

Installing `tcld` currently requires a Go toolchain. Publishing pre-compiled binaries on GitHub Releases removes that friction — users can download, make executable, and go.

GoReleaser handles cross-compilation, archive packaging (`.tar.gz` for Linux/macOS, `.zip` for Windows), and SHA256 checksum generation. The release workflow uses only the default `GITHUB_TOKEN` — no extra secrets required.

The existing `make release` target and PR pipeline are untouched.

## Checklist

1. Closes #496

2. How was this tested:
   - `goreleaser check` — config validated successfully
   - `goreleaser release --snapshot --clean` — dry-run confirmed all 5 target binaries and archives build correctly

3. Any docs updates needed?
   No — the README installation instructions can be updated separately once binaries are live on the Releases page.